### PR TITLE
Refactored existing files/classes/tests to follow C# standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -342,3 +342,7 @@ healthchecksdb
 
 # Backup folder for Package Reference Convert tool in Visual Studio 2017
 MigrationBackup/
+.idea/.idea.SearchTool/.idea/indexLayout.xml
+.idea/.idea.SearchTool/.idea/vcs.xml
+.idea/.idea.SearchTool/.idea/encodings.xml
+.idea/.idea.SearchTool/.idea/.name

--- a/.idea/.idea.SearchTool/.idea/.gitignore
+++ b/.idea/.idea.SearchTool/.idea/.gitignore
@@ -1,0 +1,13 @@
+﻿# Default ignored files
+/shelf/
+/workspace.xml
+# Rider ignored files
+/projectSettingsUpdater.xml
+/modules.xml
+/contentModel.xml
+/.idea.SearchTool.iml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/SearchTool/Search.cs
+++ b/SearchTool/Search.cs
@@ -33,63 +33,22 @@
     */
 
 
-    // TODO: Standardise the naming scheme for readability
-    public record SearchRecord
-    {
-        public SearchRecord(string searchQuery)
-        {
-            this.searchQuery = searchQuery;
-        }
-
-        public SearchRecord(string searchQuery, int initialPosition)
-        {
-            this.searchQuery = searchQuery;
-            this.initialPosition = initialPosition;
-        }
-
-        public int initialPosition { get; set; }
-        public string searchQuery { get; init; }
-    }
-
-    public record SearchQuery
-    {
-        public SearchQuery(string searchSpace, string searchQuery)
-        {
-            this.searchSpace = searchSpace;
-            this.searchQuery = searchQuery;
-        }
-
-        public SearchQuery(string searchSpace, string searchQuery,
-                            int initialPosition, int finalPosition)
-        {
-            this.searchSpace = searchSpace;
-            this.searchQuery = searchQuery;
-            this.initialPosition = initialPosition;
-            this.finalPosition = finalPosition;
-        }
-
-        public int initialPosition { get; set; }
-        public int finalPosition { get; set; }
-        public string searchSpace { get; init; }
-        public string searchQuery { get; init; }
-    }
-
-    // ======================================================================
-
     public static class Search
     {
-        public static readonly string wildcardToken = @"\?";
+        public static readonly string WildcardToken = @"\?";
 
         // Returs a bool denoting whether the search query is contained in the search space
         public static bool ContainsString(SearchQuery search)
         {
-            for (int index = 0; index < search.searchSpace.Length; ++index)
+            
+            //TODO Use existing string operations to perform this search
+            for (int index = 0; index < search.SearchSpace.Length; ++index)
             {
-                var foundFirstCharOfSearchQuery = search.searchSpace[index] == search.searchQuery[0];
+                var foundFirstCharOfSearchQuery = search.SearchSpace[index] == search.SearchQuery[0];
                 if (foundFirstCharOfSearchQuery)
                 {
                     // Assert whether the current substring@Index matches the full search query
-                    if (AssertSearchInput(search.searchQuery, search.searchSpace, index))
+                    if (AssertSearchInput(search.SearchQuery, search.SearchSpace, index))
                     {
                         return true;
                     }
@@ -102,18 +61,19 @@
         // Returns a list of every occurrence of the search query that was found in the 'search space'
         public static List<SearchRecord> FindString(SearchQuery search)
         {
+            //TODO Use existing string operations to perform this search
             var recordList = new List<SearchRecord>();
 
-            for (int index = 0; index < search.searchSpace.Length; ++index)
+            for (int index = 0; index < search.SearchSpace.Length; ++index)
             {
                 // If we find the search queries first char in the search space
-                var foundFirstCharOfSearchQuery = search.searchSpace[index] == search.searchQuery[0];
+                var foundFirstCharOfSearchQuery = search.SearchSpace[index] == search.SearchQuery[0];
                 if (foundFirstCharOfSearchQuery)
                 {
                     // Assert whether the current substring@Index matches the full search query
-                    if (AssertSearchInput(search.searchQuery, search.searchSpace, index))
+                    if (AssertSearchInput(search.SearchQuery, search.SearchSpace, index))
                     {
-                        recordList.Add(new SearchRecord(search.searchQuery, index));
+                        recordList.Add(new SearchRecord(search.SearchQuery, index));
                     }
                 }
             }
@@ -129,13 +89,13 @@
             // PROBLEM: Should there be multiple instances (say n instances) of strings satisfying rule 1 at nearly the same position then
             //          it spawns multiple nearly identical results. If this occurs multiple times (say m times) for what would otherwise
             //          be a single result; then it would result in the query returning a crossproduct of n^m nearly identical results.
-            var listofQuerySubstrings = CutoutWildcard(search.searchQuery);
-            var searchSpace = search.searchSpace;
+            var listofQuerySubstrings = CutoutWildcard(search.SearchQuery);
+            var searchSpace = search.SearchSpace;
             var querySubstringCount = listofQuerySubstrings.Count();
 
             // Bail out fast on an empty search
             bool bailoutOnEmptySearchSpace = querySubstringCount == 0;
-            bool bailoutOnEmptyQuery = search.searchSpace.Length == 0;
+            bool bailoutOnEmptyQuery = search.SearchSpace.Length == 0;
             if (bailoutOnEmptySearchSpace || bailoutOnEmptyQuery) return new List<List<SearchRecord>>();
 
             // Get the first char of every substring query to simplify the search
@@ -161,7 +121,7 @@
                         if (AssertSearchInput(listofQuerySubstrings[searchQueryListIndex], searchSpace, searchSpaceIndex))
                         {
                             substringSearchRecords[searchQueryListIndex].Add(
-                            new SearchRecord(search.searchQuery, searchSpaceIndex));
+                            new SearchRecord(search.SearchQuery, searchSpaceIndex));
                         }
                     }
                 }
@@ -222,8 +182,8 @@
                     visitedSubstringRecordTable[visitedRecordIndex].ForEach(visit => hasVisitedAllSubstrings = hasVisitedAllSubstrings && visit);
                     if (hasVisitedAllSubstrings) return searchResults;
 
-                    int highestSubstring = substringSearchRecords[visitedRecordIndex].Min(val => val.initialPosition);
-                    var leastViableSubstring = substringSearchRecords[visitedRecordIndex].Where(val => val.initialPosition == highestSubstring).ToArray()[0]; // Cursed
+                    int highestSubstring = substringSearchRecords[visitedRecordIndex].Min(val => val.InitialPosition);
+                    var leastViableSubstring = substringSearchRecords[visitedRecordIndex].Where(val => val.InitialPosition == highestSubstring).ToArray()[0]; // Cursed
 
                     // The branching statements below initialized this variable at every path so it will never be null.
                     SearchRecord previousSubstringRecord = leastViableSubstring;
@@ -243,7 +203,7 @@
                     {
                         var currentRecord = substringSearchRecords[visitedRecordIndex][visitedSubstringIndex];
                         bool substringHasBeenVisited = visitedSubstringRecordTable[visitedRecordIndex][visitedSubstringIndex];
-                        bool substringRuleTwo = currentRecord.initialPosition >= previousSubstringRecord.initialPosition + previousSubstringRecord.searchQuery.Length;
+                        bool substringRuleTwo = currentRecord.InitialPosition >= previousSubstringRecord.InitialPosition + previousSubstringRecord.SearchQuery.Length;
                         if (substringHasBeenVisited) continue;
                         if (substringRuleTwo) bestSubstring = currentRecord;
 
@@ -267,10 +227,10 @@
 
         private static List<string> CutoutWildcard(string searchQuery)
         {
-            var wildcardTokenLength = wildcardToken.Length;
+            var wildcardTokenLength = WildcardToken.Length;
 
             // Find every wildcard in the searchQuery
-            var wildcardSearchRecord = new SearchQuery(searchQuery, wildcardToken);
+            var wildcardSearchRecord = new SearchQuery(searchQuery, WildcardToken);
             var wildcardTokens = FindString(wildcardSearchRecord);
 
             // Bailout fast in case there isn't a wildcard
@@ -282,8 +242,8 @@
             var result = new List<string>();
             foreach (var wildcardToken in wildcardTokens)
             {
-                result.Add(searchQuery.Substring(position, wildcardToken.initialPosition - position));
-                position += wildcardToken.initialPosition - position + wildcardTokenLength;
+                result.Add(searchQuery.Substring(position, wildcardToken.InitialPosition - position));
+                position += wildcardToken.InitialPosition - position + wildcardTokenLength;
             }
 
             // Edgecase: catching the last substring

--- a/SearchTool/SearchQuery.cs
+++ b/SearchTool/SearchQuery.cs
@@ -1,0 +1,20 @@
+﻿namespace SearchTool;
+
+public record SearchQuery:SearchRecord
+{
+    public SearchQuery(string searchSpace, string searchQuery) : base(searchQuery)
+    {
+        this.SearchSpace = searchSpace;
+    }
+
+    public SearchQuery(string searchSpace, string searchQuery,
+        int initialPosition, int finalPosition) : base(searchQuery, initialPosition)
+    {
+        this.SearchSpace = searchSpace;
+        this.FinalPosition = finalPosition;
+    }
+
+    public int FinalPosition { get; set; }
+    public string SearchSpace { get; init; }
+
+}

--- a/SearchTool/SearchRecord.cs
+++ b/SearchTool/SearchRecord.cs
@@ -1,0 +1,18 @@
+﻿namespace SearchTool;
+
+public record SearchRecord
+{
+    public SearchRecord(string searchQuery)
+    {
+        this.SearchQuery = searchQuery;
+    }
+
+    public SearchRecord(string searchQuery, int initialPosition)
+    {
+        this.SearchQuery = searchQuery;
+        this.InitialPosition = initialPosition;
+    }
+
+    public int InitialPosition { get; set; }
+    public string SearchQuery { get; init; }
+}

--- a/TestSearchTool/TestSearchRecord.cs
+++ b/TestSearchTool/TestSearchRecord.cs
@@ -1,0 +1,56 @@
+﻿using NUnit.Framework;
+using SearchTool;
+
+namespace TestSearchTool;
+
+[TestFixture]
+public class TestSearchRecord
+{
+    [Test]
+    public void ContainsString_QueryNotContainedInSearchSpace()
+    {
+        var randomSearchSpace = "1idoieogi42hfwq9023u48t02843";
+        var queryNotContainedInSearchSpace = " ";
+        var query = new SearchQuery(randomSearchSpace, queryNotContainedInSearchSpace);
+
+        bool result = Search.ContainsString(query);
+
+        Assert.IsFalse(result);
+    }
+
+    [Test]
+    public void ContainsString_String_QueryContainedInSearchSpace()
+    {
+        var randomSearchSpace = "1idoieogi42hfwq9023u48t02843";
+        var queryContainedInSearchSpace = "1i";
+        var query = new SearchQuery(randomSearchSpace, queryContainedInSearchSpace);
+
+        bool result = Search.ContainsString(query);
+
+        Assert.IsTrue(result);
+    }
+
+    [Test]
+    public void ContainsString_SingleCharacter_QueryContainedInSearchSpace()
+    {
+        var randomSearchSpace = "1idoieogi42hfwq9023u48t02843";
+        var queryContainedInSearchSpace = "1";
+        var query = new SearchQuery(randomSearchSpace, queryContainedInSearchSpace);
+
+        bool result = Search.ContainsString(query);
+
+        Assert.IsTrue(result);
+    }
+
+    [Test]
+    public void ContainsString_String_QueryContainedInTheSearchSpace_PlacedAtTheEnd()
+    {
+        var randomSearchSpace = "1idoieogi42hfwq9023u48t02843";
+        var queryContainedInSearchSpace = "02843";
+        var query = new SearchQuery(randomSearchSpace, queryContainedInSearchSpace);
+
+        bool result = Search.ContainsString(query);
+
+        Assert.IsTrue(result);
+    }
+}

--- a/TestSearchTool/TestSearchTool.cs
+++ b/TestSearchTool/TestSearchTool.cs
@@ -2,230 +2,162 @@ using NUnit.Framework;
 using SearchTool;
 using System.Collections.Generic; // Needed to avoid name collision between NUnit List and Generic List<>
 
-namespace TestSearchTool
+namespace TestSearchTool;
+/*
+     [Test, Order()]
+     public void _() 
+     {
+
+     }
+ */
+
+[TestFixture]
+public class TestSearchQuery
 {
-    /*
-         [Test, Order()]
-         public void _() 
-         {
+    private readonly string WildcardString = Search.WildcardToken;
 
-         }
-     */
-
-    [TestFixture]
-    public class Search_TestContainsString
+    [Test]
+    public void FindString_QueryNotContainedInSearchSpace()
     {
-        [Test]
-        public void ContainsString_QueryNotContainedInSearchSpace()
-        {
-            var randomSearchSpace = "1idoieogi42hfwq9023u48t02843";
-            var queryNotContainedInSearchSpace = " ";
-            var query = new SearchQuery(randomSearchSpace, queryNotContainedInSearchSpace);
+        string searchSpace = "21+e921ur24hgfwneodjqlnv+r4039t530yt834";
+        string query = " ";
+        var searchQuery = new SearchQuery(searchSpace, query);
+        List<SearchRecord> expectedSearchResultList = new List<SearchRecord>();
 
-            bool result = Search.ContainsString(query);
+        List<SearchRecord> result = Search.FindString(searchQuery);
 
-            Assert.IsFalse(result);
-        }
-
-        [Test]
-        public void ContainsString_String_QueryContainedInSearchSpace()
-        {
-            var randomSearchSpace = "1idoieogi42hfwq9023u48t02843";
-            var queryContainedInSearchSpace = "1i";
-            var query = new SearchQuery(randomSearchSpace, queryContainedInSearchSpace);
-
-            bool result = Search.ContainsString(query);
-
-            Assert.IsTrue(result);
-        }
-
-        [Test]
-        public void ContainsString_SingleCharacter_QueryContainedInSearchSpace()
-        {
-            var randomSearchSpace = "1idoieogi42hfwq9023u48t02843";
-            var queryContainedInSearchSpace = "1";
-            var query = new SearchQuery(randomSearchSpace, queryContainedInSearchSpace);
-
-            bool result = Search.ContainsString(query);
-
-            Assert.IsTrue(result);
-        }
-
-        [Test]
-        public void ContainsString_String_QueryContainedInTheSearchSpace_PlacedAtTheEnd()
-        {
-            var randomSearchSpace = "1idoieogi42hfwq9023u48t02843";
-            var queryContainedInSearchSpace = "02843";
-            var query = new SearchQuery(randomSearchSpace, queryContainedInSearchSpace);
-
-            bool result = Search.ContainsString(query);
-
-            Assert.IsTrue(result);
-        }
+        Assert.That(result, Is.EqualTo(expectedSearchResultList));
     }
 
-    [TestFixture]
-    public class Search_TestFindString
+    [Test]
+    public void FindString_SingleCharacter_QueryContainedInSearchSpaceOnce()
     {
-        [Test]
-        public void FindString_QueryNotContainedInSearchSpace()
+        string searchSpace = "21+e921ur24hgfwneodjqlnv+r4039t530yt834";
+        string query = "f";
+        var expectedSearchRecord1 = new SearchRecord(query, 13);
+        var queryRecord = new SearchQuery(searchSpace, query);
+        List<SearchRecord> expectedSearchResultList = new List<SearchRecord>
         {
-            var searchSpace = "21+e921ur24hgfwneodjqlnv+r4039t530yt834";
-            var query = " ";
-            var searchQuery = new SearchQuery(searchSpace, query);
-            var expectedSearchResultList = new List<SearchRecord>();
+            expectedSearchRecord1
+        };
 
-            var result = Search.FindString(searchQuery);
+        List<SearchRecord> result = Search.FindString(queryRecord);
 
-            Assert.That(result, Is.EqualTo(expectedSearchResultList));
-
-        }
-
-        [Test]
-        public void FindString_SingleCharacter_QueryContainedInSearchSpaceOnce()
-        {
-            var searchSpace = "21+e921ur24hgfwneodjqlnv+r4039t530yt834";
-            var query = "f";
-            var expectedSearchRecord1 = new SearchRecord(query, 13);
-            var queryRecord = new SearchQuery(searchSpace, query);
-            var expectedSearchResultList = new List<SearchRecord> {
-                expectedSearchRecord1
-            };
-
-            var result = Search.FindString(queryRecord);
-
-            Assert.That(expectedSearchResultList, Is.EqualTo(result));
-        }
-
-        [Test]
-        public void FindString_SingleCharacter_QueryContainedInSearchSpaceMultipleTimes()
-        {
-            var searchSpace = "21+e921ur24hgfwneodjqlnv+r4039t530yt834";
-            var query = "+";
-            var expectedSearchRecord1 = new SearchRecord(query, 2);
-            var expectedSearchRecord2 = new SearchRecord(query, 24);
-            var queryRecord = new SearchQuery(searchSpace, query);
-            var expectedSearchResultList = new List<SearchRecord> {
-                expectedSearchRecord1, expectedSearchRecord2
-            };
-
-            var result = Search.FindString(queryRecord);
-
-            Assert.That(expectedSearchResultList, Is.EqualTo(result));
-        }
-
-        [Test]
-        public void FindString_String_QueryContainedInSearchSpaceOnce()
-        {
-            var searchSpace = "21+e921ur24hgfwneodjqlnv+r4039t530yt834";
-            var query = "ur24";
-            var expectedSearchRecord1 = new SearchRecord(query, 7);
-            var searchQuery = new SearchQuery(searchSpace, query);
-            var expectedSearchResultList = new List<SearchRecord> {
-                expectedSearchRecord1
-            };
-
-            var result = Search.FindString(searchQuery);
-
-            Assert.That(expectedSearchResultList, Is.EqualTo(result));
-        }
-
-        [Test]
-        public void FindString_String_QueryContainedInSearchSpaceMultipleTimes()
-        {
-            var searchSpace = "21+e921ur24hgfwneodjqlnv+r4039t530yt834";
-            var query = "21";
-            var expectedSearchRecord1 = new SearchRecord(query, 0);
-            var expectedSearchRecord2 = new SearchRecord(query, 5);
-            var queryRecord = new SearchQuery(searchSpace, query);
-            var expectedSearchResultList = new List<SearchRecord> {
-                expectedSearchRecord1, expectedSearchRecord2
-            };
-
-            var result = Search.FindString(queryRecord);
-
-            Assert.That(expectedSearchResultList, Is.EqualTo(result));
-        }
-
-        [Test]
-        public void FindString_QueryPrefixFoundAtTheEndOfSearchSpace()
-        {
-            var searchSpace = "21+e921ur24hgfwneodjqlnv+r4039t530yt834";
-            var query = "3472";
-            var queryRecord = new SearchQuery(searchSpace, query);
-            var expectedSearchResultList = new List<SearchRecord>();
-
-            var result = Search.FindString(queryRecord);
-
-            Assert.That(expectedSearchResultList, Is.EqualTo(result));
-        }
+        Assert.That(expectedSearchResultList, Is.EqualTo(result));
     }
 
-    [TestFixture]
-    public class Search_TestGenericWildcardSearch
+    [Test]
+    public void FindString_SingleCharacter_QueryContainedInSearchSpaceMultipleTimes()
     {
-        string wildcardString = Search.wildcardToken;
-
-        [Test]
-        public void GenericWildcardSearch_SearchWithWildcardOnly_SearchForSomeString()
+        string searchSpace = "21+e921ur24hgfwneodjqlnv+r4039t530yt834";
+        string query = "+";
+        var expectedSearchRecord1 = new SearchRecord(query, 2);
+        var expectedSearchRecord2 = new SearchRecord(query, 24);
+        var queryRecord = new SearchQuery(searchSpace, query);
+        List<SearchRecord> expectedSearchResultList = new List<SearchRecord>
         {
-            var query = "someString";
-            var searchSpace = wildcardString;
-            var searchQuery = new SearchQuery(searchSpace, query);
-            var expectedResult = new List<List<SearchRecord>>();
+            expectedSearchRecord1, expectedSearchRecord2
+        };
 
-            var actualResult = Search.GenericWildcardSearch(searchQuery);
+        List<SearchRecord> result = Search.FindString(queryRecord);
 
-            Assert.That(expectedResult == actualResult);
-        }
-
-        [Test]
-        public void GenericWildcardSearch_SearchWithWildcardOnly_SearchForEmptyString()
-        {
-            var searchQuery = wildcardString;
-
-        }
-
-        [Test]
-        public void GenericWildcardSearch_SearchWithoutWildcard()
-        {
-
-        }
-
-        [Test]
-        public void GenericWildcardSearch_SearchWithSingleWildcard()
-        {
-
-        }
-
-        [Test]
-        public void GenericWildcardSearch_SearchWithMultipleWildcards()
-        {
-
-        }
-
-        [Test]
-        public void GenericWildcardSearch_WildcardPlacedAtTheStartOfSearchQuery()
-        {
-
-        }
-
-        [Test]
-        public void GenericWildcardSearch_WildcardPlacedAtTheEndOfSearchQuery()
-        {
-
-        }
-
-        [Test]
-        public void GenericWildcardSearch_TwoWildcardsPlacedConsecutively()
-        {
-
-        }
+        Assert.That(expectedSearchResultList, Is.EqualTo(result));
     }
 
-    [TestFixture]
-    public class Search_TestSemanticWildcardSearch
+    [Test]
+    public void FindString_String_QueryContainedInSearchSpaceOnce()
     {
+        string searchSpace = "21+e921ur24hgfwneodjqlnv+r4039t530yt834";
+        string query = "ur24";
+        var expectedSearchRecord1 = new SearchRecord(query, 7);
+        var searchQuery = new SearchQuery(searchSpace, query);
+        List<SearchRecord> expectedSearchResultList = new List<SearchRecord>
+        {
+            expectedSearchRecord1
+        };
 
+        List<SearchRecord> result = Search.FindString(searchQuery);
+
+        Assert.That(expectedSearchResultList, Is.EqualTo(result));
+    }
+
+    [Test]
+    public void FindString_String_QueryContainedInSearchSpaceMultipleTimes()
+    {
+        string searchSpace = "21+e921ur24hgfwneodjqlnv+r4039t530yt834";
+        string query = "21";
+        var expectedSearchRecord1 = new SearchRecord(query, 0);
+        var expectedSearchRecord2 = new SearchRecord(query, 5);
+        var queryRecord = new SearchQuery(searchSpace, query);
+        List<SearchRecord> expectedSearchResultList = new List<SearchRecord>
+        {
+            expectedSearchRecord1, expectedSearchRecord2
+        };
+
+        List<SearchRecord> result = Search.FindString(queryRecord);
+
+        Assert.That(expectedSearchResultList, Is.EqualTo(result));
+    }
+
+    [Test]
+    public void FindString_QueryPrefixFoundAtTheEndOfSearchSpace()
+    {
+        string searchSpace = "21+e921ur24hgfwneodjqlnv+r4039t530yt834";
+        string query = "3472";
+        var queryRecord = new SearchQuery(searchSpace, query);
+        List<SearchRecord> expectedSearchResultList = new List<SearchRecord>();
+
+        List<SearchRecord> result = Search.FindString(queryRecord);
+
+        Assert.That(expectedSearchResultList, Is.EqualTo(result));
+    }
+
+    [Test]
+    public void GenericWildcardSearch_SearchWithWildcardOnly_SearchForSomeString()
+    {
+        string query = "someString";
+        string searchSpace = WildcardString;
+        var searchQuery = new SearchQuery(searchSpace, query);
+        List<List<SearchRecord>> expectedResult = new List<List<SearchRecord>>();
+
+        List<List<SearchRecord>> actualResult = Search.GenericWildcardSearch(searchQuery);
+
+        Assert.That(expectedResult == actualResult);
+    }
+
+    [Test]
+    public void GenericWildcardSearch_SearchWithWildcardOnly_SearchForEmptyString()
+    {
+        string searchQuery = WildcardString;
+    }
+
+    [Test]
+    public void GenericWildcardSearch_SearchWithoutWildcard()
+    {
+    }
+
+    [Test]
+    public void GenericWildcardSearch_SearchWithSingleWildcard()
+    {
+    }
+
+    [Test]
+    public void GenericWildcardSearch_SearchWithMultipleWildcards()
+    {
+    }
+
+    [Test]
+    public void GenericWildcardSearch_WildcardPlacedAtTheStartOfSearchQuery()
+    {
+    }
+
+    [Test]
+    public void GenericWildcardSearch_WildcardPlacedAtTheEndOfSearchQuery()
+    {
+    }
+
+    [Test]
+    public void GenericWildcardSearch_TwoWildcardsPlacedConsecutively()
+    {
     }
 }


### PR DESCRIPTION
The standards are as follows:
- Properties are always named with PascalCase --- they should only provide as much information as the outside needs. Readonly, private, protected are preferred over public. Provide only the public with the functionality they need. 
- One class/type per file only
- One test class per class to test. If you think you the test class is too large, its an indicator that the class under test 'smells'. Consider hiding some of the functionality using composition. Have the class have some object that performs some of the functionality. 
- Use inheritance if a class/record contains the same information/properties.